### PR TITLE
スクロールレイアウトが破損する問題の修正

### DIFF
--- a/scripts/AEintersectionMarkerTemplate.mel
+++ b/scripts/AEintersectionMarkerTemplate.mel
@@ -19,6 +19,7 @@ proc _registerNodeHelp(string $type, string $cmd)
 
 global proc AEintersectionMarkerTemplate(string $nodename)
 {
+    editorTemplate -beginScrollLayout;
     editorTemplate -beginLayout "Intersection Marker Attributes" -collapse 0;
 
     {
@@ -61,8 +62,8 @@ global proc AEintersectionMarkerTemplate(string $nodename)
 
     AEdependNodeTemplate($nodename);
 
-    editorTemplate("-addExtraControls");
-    editorTemplate("-endScrollLayout");
+    editorTemplate -addExtraControls;
+    editorTemplate -endScrollLayout;
 }
 
 // AEIntersectionMarkerNodeTemplate($gAECurrentTab);


### PR DESCRIPTION
intersectionMarkerのアトリビュートエディタを開き、本来スクロールレイアウトが発生する状態にするとスクロールが出来なくなり、他ノードのアトリビュートエディタにも派生しMaya起動中直らなくなる。

intersectionMarkerノードのAEテンプレート内スクロールレイアウトが正常に起動と終了がされていなかったことが原因。